### PR TITLE
Add onboarding modal and role-based themes

### DIFF
--- a/src/app/ClientBody.tsx
+++ b/src/app/ClientBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { UserProvider } from "@/context/UserContext";
 
 export default function ClientBody({
   children,
@@ -9,9 +10,12 @@ export default function ClientBody({
 }) {
   // Remove any extension-added classes during hydration
   useEffect(() => {
-    // This runs only on the client after hydration
-    document.body.className = "antialiased";
+    document.body.classList.add("antialiased");
   }, []);
 
-  return <div className="antialiased">{children}</div>;
+  return (
+    <UserProvider>
+      <div className="antialiased">{children}</div>
+    </UserProvider>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -186,3 +186,14 @@ html {
 .header-link:hover::after {
   width: 80%;
 }
+
+/* Role themes */
+.theme-marketer {
+  background-color: #faf5ff;
+}
+.theme-technologist {
+  background-color: #f0f9ff;
+}
+.theme-executive {
+  background-color: #f5f7fa;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,9 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Callout from "@/components/Callout";
 import LightWavesBackground from "@/components/LightWavesBackground";
+import OnboardingModal from "@/components/OnboardingModal";
+import BentoGrid from "@/components/BentoGrid";
+import CopilotButton from "@/components/CopilotButton";
 
 export default function Home() {
   return (
@@ -10,8 +13,11 @@ export default function Home() {
       <div className="relative z-10">
         <Header />
         <main>
+          <OnboardingModal />
           <Hero />
+          <BentoGrid />
           <Callout />
+          <CopilotButton />
         </main>
       </div>
     </div>

--- a/src/components/BentoGrid.tsx
+++ b/src/components/BentoGrid.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useContext } from "react";
+import UserContext from "@/context/UserContext";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Lightbulb, Monitor, Briefcase } from "lucide-react";
+
+import type { ElementType } from "react";
+
+interface Tile {
+  title: string;
+  description: string;
+  icon: ElementType;
+  roles?: string[];
+}
+
+const tiles: Tile[] = [
+  {
+    title: "Latest Insight",
+    description: "Trend analysis for marketing teams",
+    icon: Lightbulb,
+    roles: ["Marketer"],
+  },
+  {
+    title: "Tech Demo",
+    description: "Showcase of our newest tools",
+    icon: Monitor,
+    roles: ["Technologist"],
+  },
+  {
+    title: "Executive Stats",
+    description: "Key numbers for decision makers",
+    icon: Briefcase,
+    roles: ["Executive"],
+  },
+];
+
+export default function BentoGrid() {
+  const { role } = useContext(UserContext);
+  const filtered = role
+    ? tiles.filter((t) => !t.roles || t.roles.includes(role))
+    : tiles;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 py-8">
+      {filtered.map((tile) => (
+        <Card key={tile.title} className="hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center space-x-2">
+            <tile.icon className="h-5 w-5 text-sitecore-purple" />
+            <CardTitle>{tile.title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>{tile.description}</CardDescription>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -8,7 +8,7 @@ import {
   Mail,
   Phone,
   Users,
-  Zap
+  Zap,
 } from "lucide-react";
 
 export default function CTA() {
@@ -19,7 +19,7 @@ export default function CTA() {
       description: "Contact us",
       action: "Contact us",
       variant: "default" as const,
-      href: "#contact"
+      href: "#contact",
     },
     {
       icon: Calendar,
@@ -27,7 +27,7 @@ export default function CTA() {
       description: "Explore Webinars",
       action: "View events",
       variant: "outline" as const,
-      href: "#webinars"
+      href: "#webinars",
     },
     {
       icon: HeadphonesIcon,
@@ -35,8 +35,8 @@ export default function CTA() {
       description: "Access Support portal",
       action: "Get help",
       variant: "outline" as const,
-      href: "#support"
-    }
+      href: "#support",
+    },
   ];
 
   return (
@@ -45,7 +45,7 @@ export default function CTA() {
         {/* Main CTA */}
         <div className="text-center mb-20">
           <Card className="border-0 bg-gradient-purple text-white overflow-hidden relative">
-            <div className="absolute inset-0 bg-grid-pattern opacity-10"></div>
+            <div className="absolute inset-0 bg-grid-pattern opacity-10" />
             <CardContent className="relative p-12 lg:p-20">
               <div className="max-w-3xl mx-auto space-y-8">
                 <div className="space-y-6">
@@ -53,17 +53,25 @@ export default function CTA() {
                     Get started with a demo
                   </h2>
                   <p className="text-xl text-white/90 max-w-2xl mx-auto">
-                    Take the first step to achieving your digital experience goals.
-                    Let us show you how Sitecore can help your brand deliver exceptional experiences.
+                    Take the first step to achieving your digital experience
+                    goals. Let us show you how Sitecore can help your brand
+                    deliver exceptional experiences.
                   </p>
                 </div>
 
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                  <Button size="lg" className="bg-white text-sitecore-purple hover:bg-white/90">
+                  <Button
+                    size="lg"
+                    className="bg-white text-sitecore-purple hover:bg-white/90"
+                  >
                     Request a demo
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
-                  <Button size="lg" variant="outline" className="border-white text-white hover:bg-white hover:text-sitecore-purple">
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="border-white text-white hover:bg-white hover:text-sitecore-purple"
+                  >
                     <Phone className="mr-2 h-4 w-4" />
                     Schedule a call
                   </Button>
@@ -81,7 +89,9 @@ export default function CTA() {
                       <div className="inline-flex items-center justify-center w-12 h-12 bg-white/20 rounded-full mb-3">
                         <Zap className="h-6 w-6" />
                       </div>
-                      <p className="text-sm text-white/80">AI-Powered Platform</p>
+                      <p className="text-sm text-white/80">
+                        AI-Powered Platform
+                      </p>
                     </div>
                     <div>
                       <div className="inline-flex items-center justify-center w-12 h-12 bg-white/20 rounded-full mb-3">
@@ -98,26 +108,25 @@ export default function CTA() {
 
         {/* Secondary CTAs */}
         <div className="grid md:grid-cols-3 gap-8">
-          {ctaOptions.map((option, index) => (
-            <Card key={index} className="group hover:shadow-lg transition-all duration-300 cursor-pointer">
+          {ctaOptions.map((option) => (
+            <Card
+              key={option.title}
+              className="group hover:shadow-lg transition-all duration-300 cursor-pointer"
+            >
               <CardContent className="p-8 text-center">
                 <div className="mb-6">
                   <div className="inline-flex items-center justify-center w-16 h-16 bg-sitecore-purple/10 rounded-2xl mb-4 group-hover:bg-sitecore-purple/20 transition-colors">
                     <option.icon className="h-8 w-8 text-sitecore-purple" />
                   </div>
-                  <h3 className="text-xl font-semibold mb-2">
-                    {option.title}
-                  </h3>
-                  <p className="text-muted-foreground">
-                    {option.description}
-                  </p>
+                  <h3 className="text-xl font-semibold mb-2">{option.title}</h3>
+                  <p className="text-muted-foreground">{option.description}</p>
                 </div>
                 <Button
                   variant={option.variant}
                   className={`w-full ${
-                    option.variant === 'default'
-                      ? 'bg-sitecore-purple hover:bg-sitecore-purple/90 text-white'
-                      : 'border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white'
+                    option.variant === "default"
+                      ? "bg-sitecore-purple hover:bg-sitecore-purple/90 text-white"
+                      : "border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white"
                   }`}
                 >
                   {option.action}
@@ -138,12 +147,18 @@ export default function CTA() {
                   <div className="h-12 w-24 bg-muted rounded flex items-center justify-center mx-auto mb-4">
                     <span className="text-xs font-bold">GARTNER</span>
                   </div>
-                  <h4 className="font-semibold mb-2">2025 Gartner Magic Quadrant</h4>
+                  <h4 className="font-semibold mb-2">
+                    2025 Gartner Magic Quadrant
+                  </h4>
                   <p className="text-sm text-muted-foreground mb-4">
                     for Digital Asset Management Platforms
                   </p>
                 </div>
-                <Button variant="outline" size="sm" className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white"
+                >
                   See Gartner report
                   <ArrowRight className="ml-2 h-3 w-3" />
                 </Button>
@@ -156,12 +171,18 @@ export default function CTA() {
                   <div className="h-12 w-24 bg-muted rounded flex items-center justify-center mx-auto mb-4">
                     <span className="text-xs font-bold">GARTNER</span>
                   </div>
-                  <h4 className="font-semibold mb-2">2025 Gartner Magic Quadrant</h4>
+                  <h4 className="font-semibold mb-2">
+                    2025 Gartner Magic Quadrant
+                  </h4>
                   <p className="text-sm text-muted-foreground mb-4">
                     for Digital Experience Platforms
                   </p>
                 </div>
-                <Button variant="outline" size="sm" className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white"
+                >
                   See Gartner report
                   <ArrowRight className="ml-2 h-3 w-3" />
                 </Button>
@@ -179,7 +200,11 @@ export default function CTA() {
                     Worldwide Hybrid Headless CMS 2023
                   </p>
                 </div>
-                <Button variant="outline" size="sm" className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-sitecore-purple text-sitecore-purple hover:bg-sitecore-purple hover:text-white"
+                >
                   See IDC report
                   <ArrowRight className="ml-2 h-3 w-3" />
                 </Button>

--- a/src/components/CopilotButton.tsx
+++ b/src/components/CopilotButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function CopilotButton() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Array<{ id: string; text: string }>>(
+    [],
+  );
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    setMessages([...messages, { id: crypto.randomUUID(), text: input }]);
+    setInput("");
+  };
+
+  return (
+    <>
+      <button
+        className="fixed bottom-6 right-6 bg-sitecore-core-red text-white rounded-full px-4 py-2 shadow-lg"
+        onClick={() => setOpen(true)}
+      >
+        Ask Copilot
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-end justify-end z-50">
+          <div className="bg-background w-full max-w-md m-4 p-4 rounded-lg shadow-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="font-semibold">Copilot</h2>
+              <button onClick={() => setOpen(false)}>✕</button>
+            </div>
+            <div className="h-60 overflow-y-auto border rounded mb-2 p-2 space-y-2">
+              {messages.map((m) => (
+                <div key={m.id} className="p-2 bg-muted rounded">
+                  {m.text}
+                </div>
+              ))}
+            </div>
+            <div className="flex">
+              <input
+                className="flex-1 border rounded-l p-2 bg-background"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+              />
+              <Button className="rounded-l-none" onClick={handleSend}>
+                Send
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -8,7 +8,7 @@ import {
   Globe,
   Shield,
   ArrowRight,
-  CheckCircle
+  CheckCircle,
 } from "lucide-react";
 
 export default function Features() {
@@ -16,48 +16,55 @@ export default function Features() {
     {
       icon: Layers,
       title: "Total solution flexibility",
-      description: "Sitecore's composable platform offers the flexibility to create a solution as unique as your business and tech stack.",
-      category: "VERSATILITY"
+      description:
+        "Sitecore's composable platform offers the flexibility to create a solution as unique as your business and tech stack.",
+      category: "VERSATILITY",
     },
     {
       icon: Users,
       title: "Connecting marketers and developers",
-      description: "Simplicity for marketers and agility for developers, enabling teams to work in harmony.",
-      category: "SYNERGY"
+      description:
+        "Simplicity for marketers and agility for developers, enabling teams to work in harmony.",
+      category: "SYNERGY",
     },
     {
       icon: BarChart3,
       title: "Unlimited scale and complexity made easy",
-      description: "Built for enterprise scale. Choose capabilities for today and add more as your vision evolves.",
-      category: "SIMPLICITY"
-    }
+      description:
+        "Built for enterprise scale. Choose capabilities for today and add more as your vision evolves.",
+      category: "SIMPLICITY",
+    },
   ];
 
   const useCases = [
     {
       icon: Zap,
       title: "Modernize your DX",
-      description: "Build and launch lightning-fast personalized experiences that drive engagement and keep customers coming back for more.",
-      href: "#modernize"
+      description:
+        "Build and launch lightning-fast personalized experiences that drive engagement and keep customers coming back for more.",
+      href: "#modernize",
     },
     {
       icon: Globe,
       title: "Manage global content",
-      description: "Craft content that matters and share it with the world through unified content management.",
-      href: "#content"
+      description:
+        "Craft content that matters and share it with the world through unified content management.",
+      href: "#content",
     },
     {
       icon: Shield,
       title: "Deliver limitless commerce",
-      description: "Create engaging, personalized ecommerce experiences wherever your customers are.",
-      href: "#commerce"
+      description:
+        "Create engaging, personalized ecommerce experiences wherever your customers are.",
+      href: "#commerce",
     },
     {
       icon: BarChart3,
       title: "Optimize with data",
-      description: "Analyze, improve, and optimize your website for better user experiences that get results.",
-      href: "#data"
-    }
+      description:
+        "Analyze, improve, and optimize your website for better user experiences that get results.",
+      href: "#data",
+    },
   ];
 
   return (
@@ -73,7 +80,10 @@ export default function Features() {
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {useCases.map((useCase, index) => (
-              <Card key={index} className="group hover:shadow-lg transition-all duration-300 cursor-pointer border-border/50 hover:border-sitecore-purple/30">
+              <Card
+                key={index}
+                className="group hover:shadow-lg transition-all duration-300 cursor-pointer border-border/50 hover:border-sitecore-purple/30"
+              >
                 <CardContent className="p-6">
                   <div className="mb-4">
                     <div className="inline-flex items-center justify-center w-12 h-12 bg-sitecore-purple/10 rounded-lg group-hover:bg-sitecore-purple/20 transition-colors">
@@ -86,7 +96,11 @@ export default function Features() {
                   <p className="text-muted-foreground text-sm leading-relaxed mb-4">
                     {useCase.description}
                   </p>
-                  <Button variant="ghost" size="sm" className="p-0 h-auto text-sitecore-purple hover:text-sitecore-purple/80">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="p-0 h-auto text-sitecore-purple hover:text-sitecore-purple/80"
+                  >
                     Learn more
                     <ArrowRight className="ml-1 h-3 w-3" />
                   </Button>
@@ -139,26 +153,34 @@ export default function Features() {
                         Sitecore Stream
                       </h2>
                       <p className="text-xl text-muted-foreground mb-6">
-                        Boost productivity and drive growth with AI and orchestration across your DXP.
+                        Boost productivity and drive growth with AI and
+                        orchestration across your DXP.
                       </p>
                       <p className="text-muted-foreground leading-relaxed mb-8">
-                        Transform your content-experience lifecycle with AI workflows, generative copilots,
-                        and brand-aware AI to work smarter, more strategically, and more securely.
+                        Transform your content-experience lifecycle with AI
+                        workflows, generative copilots, and brand-aware AI to
+                        work smarter, more strategically, and more securely.
                       </p>
                     </div>
 
                     <div className="space-y-3">
                       <div className="flex items-center space-x-3">
                         <CheckCircle className="h-5 w-5 text-green-600" />
-                        <span className="text-sm">AI-driven content orchestration</span>
+                        <span className="text-sm">
+                          AI-driven content orchestration
+                        </span>
                       </div>
                       <div className="flex items-center space-x-3">
                         <CheckCircle className="h-5 w-5 text-green-600" />
-                        <span className="text-sm">Intelligent workflow automation</span>
+                        <span className="text-sm">
+                          Intelligent workflow automation
+                        </span>
                       </div>
                       <div className="flex items-center space-x-3">
                         <CheckCircle className="h-5 w-5 text-green-600" />
-                        <span className="text-sm">Brand-aware generative AI</span>
+                        <span className="text-sm">
+                          Brand-aware generative AI
+                        </span>
                       </div>
                     </div>
 
@@ -173,8 +195,8 @@ export default function Features() {
                 <div className="relative bg-gradient-to-br from-sitecore-purple/10 to-sitecore-red/10 p-8 lg:p-12 flex items-center justify-center">
                   <div className="relative w-full max-w-sm">
                     {/* Decorative elements */}
-                    <div className="absolute -top-4 -left-4 w-24 h-24 bg-sitecore-purple/20 rounded-2xl transform rotate-12"></div>
-                    <div className="absolute -bottom-4 -right-4 w-16 h-16 bg-sitecore-red/20 rounded-xl transform -rotate-12"></div>
+                    <div className="absolute -top-4 -left-4 w-24 h-24 bg-sitecore-purple/20 rounded-2xl transform rotate-12" />
+                    <div className="absolute -bottom-4 -right-4 w-16 h-16 bg-sitecore-red/20 rounded-xl transform -rotate-12" />
                     <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 bg-gradient-purple rounded-3xl flex items-center justify-center">
                       <Zap className="h-16 w-16 text-white" />
                     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,13 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { useContext } from "react";
+import UserContext from "@/context/UserContext";
 import { Menu, X, ChevronDown, ArrowRight } from "lucide-react";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { reset } = useContext(UserContext);
 
   const navigation = [
     {
@@ -16,7 +19,7 @@ export default function Header() {
         { name: "Why Sitecore", href: "#why-sitecore" },
         { name: "Case Studies", href: "#case-studies" },
         { name: "Customer Awards", href: "#awards" },
-      ]
+      ],
     },
     {
       name: "Products & Services",
@@ -25,7 +28,7 @@ export default function Header() {
         { name: "XM Cloud", href: "#xm-cloud" },
         { name: "Personalize", href: "#personalize" },
         { name: "Content Hub", href: "#content-hub" },
-      ]
+      ],
     },
     {
       name: "Partners",
@@ -64,6 +67,9 @@ export default function Header() {
             <Link href="/join-conversation" className="header-link">
               Join the conversation
             </Link>
+            <button onClick={reset} className="header-link">
+              Reset Experience
+            </button>
           </nav>
 
           {/* CTA Button */}
@@ -109,6 +115,15 @@ export default function Header() {
                 >
                   Join the conversation
                 </Link>
+                <button
+                  className="block py-2 header-link"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    reset();
+                  }}
+                >
+                  Reset Experience
+                </button>
               </div>
               <Button className="w-full bg-sitecore-ultra-violet hover:bg-sitecore-ultra-violet/90 text-white rounded-full">
                 Visit Sitecore.com

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useContext, useEffect, useState } from "react";
+import UserContext from "@/context/UserContext";
+import { Button } from "@/components/ui/button";
+
+export default function OnboardingModal() {
+  const { role, industry, setRole, setIndustry } = useContext(UserContext);
+  const [show, setShow] = useState(false);
+  const [r, setR] = useState(role || "");
+  const [i, setI] = useState(industry || "");
+
+  useEffect(() => {
+    if (!role || !industry) {
+      setShow(true);
+    }
+  }, [role, industry]);
+
+  const handleSubmit = () => {
+    if (r && i) {
+      setRole(r);
+      setIndustry(i);
+      setShow(false);
+    }
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-full max-w-sm">
+        <h2 className="text-xl font-semibold mb-4">Welcome to Sitecore.ai</h2>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Role</label>
+            <select
+              className="w-full border rounded p-2 bg-background"
+              value={r}
+              onChange={(e) => setR(e.target.value)}
+            >
+              <option value="">Select a role</option>
+              <option>Marketer</option>
+              <option>Technologist</option>
+              <option>Executive</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Industry</label>
+            <select
+              className="w-full border rounded p-2 bg-background"
+              value={i}
+              onChange={(e) => setI(e.target.value)}
+            >
+              <option value="">Select an industry</option>
+              <option>Retail</option>
+              <option>Financial Services</option>
+              <option>Manufacturing</option>
+              <option>Healthcare</option>
+              <option>IT</option>
+            </select>
+          </div>
+          <Button
+            className="w-full bg-sitecore-purple text-white"
+            onClick={handleSubmit}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { createContext, useEffect, useState, type ReactNode } from "react";
+
+interface UserContextType {
+  role: string | null;
+  industry: string | null;
+  theme: string;
+  setRole: (r: string) => void;
+  setIndustry: (i: string) => void;
+  reset: () => void;
+}
+
+const UserContext = createContext<UserContextType>({
+  role: null,
+  industry: null,
+  theme: "",
+  setRole: () => {},
+  setIndustry: () => {},
+  reset: () => {},
+});
+
+function getTheme(role: string | null) {
+  switch (role) {
+    case "Marketer":
+      return "theme-marketer";
+    case "Technologist":
+      return "theme-technologist";
+    case "Executive":
+      return "theme-executive";
+    default:
+      return "";
+  }
+}
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [role, setRoleState] = useState<string | null>(null);
+  const [industry, setIndustryState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedRole = localStorage.getItem("role");
+    const storedIndustry = localStorage.getItem("industry");
+    if (storedRole) setRoleState(storedRole);
+    if (storedIndustry) setIndustryState(storedIndustry);
+  }, []);
+
+  const setRole = (r: string) => {
+    setRoleState(r);
+    localStorage.setItem("role", r);
+  };
+
+  const setIndustry = (i: string) => {
+    setIndustryState(i);
+    localStorage.setItem("industry", i);
+  };
+
+  const reset = () => {
+    localStorage.removeItem("role");
+    localStorage.removeItem("industry");
+    setRoleState(null);
+    setIndustryState(null);
+  };
+
+  const theme = getTheme(role);
+
+  useEffect(() => {
+    document.body.classList.remove(
+      "theme-marketer",
+      "theme-technologist",
+      "theme-executive",
+    );
+    if (theme) document.body.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <UserContext.Provider
+      value={{ role, industry, theme, setRole, setIndustry, reset }}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export default UserContext;


### PR DESCRIPTION
## Summary
- add UserContext to manage role, industry, and theme
- show onboarding modal on first visit to capture role and industry
- apply simple role themes in globals.css
- add BentoGrid and CopilotButton components
- wire components into Home page and update header with reset link

## Testing
- `bun x biome format --write`
- `bun x biome lint --write` *(fails: Found 30 errors)*
- `bun x tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684708cb36d4832d8bbdd3e45b5cb074